### PR TITLE
feat: add edit login role on reverse proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,14 +141,20 @@ services:
         target: /etc/nginx/conf.d/default.conf
         read_only: true
     secrets:
-      - htpasswd
+      - htpasswd_combined
+      - htpasswd_editor
+      - htpasswd_reader
       - ssl_private_key
     profiles:
       - vm
 
 secrets:
-  htpasswd:
-    file: /etc/apache2/.htpasswd
+  htpasswd_combined:
+    file: /etc/apache2/combined.htpasswd
+  htpasswd_editor:
+    file: /etc/apache2/editor.htpasswd
+  htpasswd_reader:
+    file: /etc/apache2/reader.htpasswd
   ssl_private_key:
     file: /etc/letsencrypt/archive/debates.swisscustodian.ch/privkey1.pem
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,7 +7,7 @@ server {
     listen 443 ssl;
     server_name debates.swisscustodian.ch;
     auth_basic "Restricted area";
-    auth_basic_user_file /run/secrets/htpasswd;
+    auth_basic_user_file /run/secrets/htpasswd_combined;
 
     # Path to certs
     ssl_certificate /etc/nginx/ssl/debates.swisscustodian.ch.cert;
@@ -20,12 +20,23 @@ server {
     # HSTS
     add_header Strict-Transport-Security "max-age=63072000" always;
 
+
+    if ($remote_user = editor) {
+	return 302 /edit;
+    }
+
     location /solr {
 	    proxy_pass http://solr:8983;
     }
     location /debates {
 	    proxy_pass http://minio-instance:9000;
     }
+    location /edit {
+        auth_basic "Editor area";
+        auth_basic_user_file /run/secrets/htpasswd_editor;
+	proxy_pass http://frontend:3000;
+    }
+
     location / {
         proxy_pass http://frontend:3000;
     }


### PR DESCRIPTION
The PR adds an edit role on the reverse proxy that redirects to an edit page in the frontend and allows the user to edit the metadata there.